### PR TITLE
bump avm-common-types and related module versions to 0.6.1 and 0.16.0

### DIFF
--- a/infra/common/types.bicep
+++ b/infra/common/types.bicep
@@ -673,7 +673,7 @@ type AppConfigurationDefinitionType = {
   }[]?
 }
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 
 @export()
 @description('Connection reference for BYOR resources inside AI Projects.')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1918,7 +1918,7 @@ resource existingCosmos 'Microsoft.DocumentDB/databaseAccounts@2025-04-15' exist
   scope: resourceGroup(_existingCosmosSub, _existingCosmosRg)
 }
 
-module databaseAccount 'br/public:avm/res/document-db/database-account:0.15.1' = if (_deployCosmos) {
+module databaseAccount 'br/public:avm/res/document-db/database-account:0.16.0' = if (_deployCosmos) {
   name: 'databaseAccountDeployment'
   params: {
     name: empty(_cosmosDef.name!) ? '${_cos}${baseName}' : _cosmosDef.name!
@@ -1988,7 +1988,7 @@ resource existingAppConfig 'Microsoft.AppConfiguration/configurationStores@2024-
   scope: resourceGroup(_existingAppcsSub, _existingAppcsRg)
 }
 
-module configurationStore 'br/public:avm/res/app-configuration/configuration-store:0.9.1' = if (_deployAppConfig) {
+module configurationStore 'br/public:avm/res/app-configuration/configuration-store:0.9.2' = if (_deployAppConfig) {
   name: 'configurationStoreDeployment'
   params: {
     name: _appConfigName
@@ -2378,7 +2378,7 @@ resource bastionVaultSecret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = if 
 }
 
 
-module jumpVm 'br/public:avm/res/compute/virtual-machine:0.18.0' = if (_deployJumpVm) {
+module jumpVm 'br/public:avm/res/compute/virtual-machine:0.20.0' = if (_deployJumpVm) {
   name: 'jumpVmDeployment'
   params: {
     name: empty(jumpVmDefinition.name!) ? '${_vm}${baseName}-jump' : jumpVmDefinition.name!
@@ -2421,7 +2421,7 @@ module jumpVm 'br/public:avm/res/compute/virtual-machine:0.18.0' = if (_deployJu
 
 
 // Only deploy Build VM when an SSH key is provided
-module buildVm 'br/public:avm/res/compute/virtual-machine:0.18.0' = if (_deployBuildVm && !empty(buildVmDefinition.sshPublicKey)) {
+module buildVm 'br/public:avm/res/compute/virtual-machine:0.20.0' = if (_deployBuildVm && !empty(buildVmDefinition.sshPublicKey)) {
   name: 'buildVmDeployment'
   params: {
     name: empty(buildVmDefinition.name!) ? '${_vm}${baseName}-build' : buildVmDefinition.name!

--- a/infra/modules/ai-foundry/main.bicep
+++ b/infra/modules/ai-foundry/main.bicep
@@ -267,7 +267,7 @@ output storageAccountName string = includeAssociatedResources ? storageAccount!.
 @description('Name of the deployed Azure Cosmos DB account.')
 output cosmosAccountName string = includeAssociatedResources ? cosmosDb!.outputs.name : ''
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 
 @export()
 @description('Custom configuration for a resource, including optional name, existing resource ID, and role assignments.')

--- a/infra/modules/ai-foundry/modules/account.bicep
+++ b/infra/modules/ai-foundry/modules/account.bicep
@@ -36,11 +36,11 @@ param privateEndpointSubnetResourceId string?
 @description('Optional. Resource Id of an existing subnet to use for agent connectivity. This is required when using agents with private endpoints.')
 param agentSubnetResourceId string?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Specifies the role assignments for the AI Foundry resource.')
 param roleAssignments roleAssignmentType[]?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of AI Foundry resources.')
 param lock lockType?
 

--- a/infra/modules/ai-foundry/modules/aiSearch.bicep
+++ b/infra/modules/ai-foundry/modules/aiSearch.bicep
@@ -14,7 +14,7 @@ param privateEndpointSubnetResourceId string?
 @description('Optional. The resource ID of the private DNS zone for the AI Search resource to establish private endpoints.')
 param privateDnsZoneResourceId string?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Specifies the role assignments for the AI Search resource.')
 param roleAssignments roleAssignmentType[]?
 

--- a/infra/modules/ai-foundry/modules/cosmosDb.bicep
+++ b/infra/modules/ai-foundry/modules/cosmosDb.bicep
@@ -14,7 +14,7 @@ param privateEndpointSubnetResourceId string?
 @description('Optional. The resource ID of the private DNS zone for the Cosmos DB to establish private endpoints.')
 param privateDnsZoneResourceId string?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Specifies the role assignments for the Cosmos DB.')
 param roleAssignments roleAssignmentType[]?
 
@@ -38,7 +38,7 @@ resource existingCosmosDb 'Microsoft.DocumentDB/databaseAccounts@2025-04-15' exi
 
 var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
 
-module cosmosDb 'br/public:avm/res/document-db/database-account:0.15.1' = if (empty(existingResourceId)) {
+module cosmosDb 'br/public:avm/res/document-db/database-account:0.16.0' = if (empty(existingResourceId)) {
   name: take('avm.res.document-db.database-account.${name}', 64)
   params: {
     name: name

--- a/infra/modules/ai-foundry/modules/keyVault.bicep
+++ b/infra/modules/ai-foundry/modules/keyVault.bicep
@@ -14,7 +14,7 @@ param privateEndpointSubnetResourceId string?
 @description('Optional. The resource ID of the private DNS zone for the Key Vault to establish private endpoints.')
 param privateDnsZoneResourceId string?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Specifies the role assignments for the Key Vault.')
 param roleAssignments roleAssignmentType[]?
 

--- a/infra/modules/ai-foundry/modules/project/main.bicep
+++ b/infra/modules/ai-foundry/modules/project/main.bicep
@@ -33,7 +33,7 @@ param aiSearchConnection azureConnectionType?
 @description('Optional. Storage Account connection for the project.')
 param storageAccountConnection azureConnectionType?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 

--- a/infra/modules/ai-foundry/modules/storageAccount.bicep
+++ b/infra/modules/ai-foundry/modules/storageAccount.bicep
@@ -14,7 +14,7 @@ param privateEndpointSubnetResourceId string?
 @description('Optional. The resource ID of the private DNS zone for the storage account blob service to establish private endpoints.')
 param blobPrivateDnsZoneResourceId string?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Specifies the role assignments for the storage account.')
 param roleAssignments roleAssignmentType[]?
 

--- a/tests/e2e/waf-aligned/dependencies.bicep
+++ b/tests/e2e/waf-aligned/dependencies.bicep
@@ -25,7 +25,7 @@ module searchService 'br/public:avm/res/search/search-service:0.11.1' = {
 }
 
 // Cosmos DB account
-module cosmosAccount 'br/public:avm/res/document-db/database-account:0.15.1' = {
+module cosmosAccount 'br/public:avm/res/document-db/database-account:0.16.0' = {
   name: 'dep-cosmos'
   params: {
     name: cosmosName


### PR DESCRIPTION
This pull request primarily updates module and type dependencies across several Bicep infrastructure files to use newer versions. These upgrades ensure compatibility with the latest features, improvements, and bug fixes from the referenced modules and shared type definitions.

**Module and Type Version Upgrades**

*Common types and role assignment/lock types:*
- Updated all imports of `roleAssignmentType` and `lockType` from `avm-common-types` from version `0.6.0` to `0.6.1` in multiple files, including `infra/common/types.bicep`, `infra/modules/ai-foundry/main.bicep`, and various module files under `infra/modules/ai-foundry/modules/`. [[1]](diffhunk://#diff-b4a8e6cb8f647b687a781229ac6e40b5bbfc9b81d183100b1138f354febd969fL676-R676) [[2]](diffhunk://#diff-7e78ea577ad2f2ed542c2f1df361f5a50cddb0fcd86e095bca5ca4d0e2ad8befL270-R270) [[3]](diffhunk://#diff-2da327712943aadf7cbed2afee369006f6cfbaca18c771beb9a77eb1c48bd737L39-R43) [[4]](diffhunk://#diff-a8ccc8b9b04a4c7f79539c3c57a65f70b15d4da4bd0ae019647342bfdd00fe06L17-R17) [[5]](diffhunk://#diff-174929a39869900500c0c3de936df608995f600e27208043ba942bb3481383acL17-R17) [[6]](diffhunk://#diff-d0222012ce4bbe257d855a0216d47f49fcb746f345b1b2d1f04b231a167a6ac8L17-R17) [[7]](diffhunk://#diff-81583fbef2720158005f45bb0399765159993ff9676e811390b91d70951c8a02L36-R36) [[8]](diffhunk://#diff-b778f73835b85cdbbdc6d9615cc841e90f4b644b9177c441927c9b767294feebL17-R17)

*Resource module version bumps:*
- Upgraded the `document-db/database-account` module from `0.15.1` to `0.16.0` in `infra/main.bicep`, `infra/modules/ai-foundry/modules/cosmosDb.bicep`, and `tests/e2e/waf-aligned/dependencies.bicep`. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1921-R1921) [[2]](diffhunk://#diff-174929a39869900500c0c3de936df608995f600e27208043ba942bb3481383acL41-R41) [[3]](diffhunk://#diff-478a4f7bd058c77ba7578722e51ccfc2d3b5687813f205032deaf57379414a02L28-R28)
- Updated the `app-configuration/configuration-store` module from `0.9.1` to `0.9.2` in `infra/main.bicep`.
- Upgraded the `compute/virtual-machine` module from `0.18.0` to `0.20.0` for both `jumpVm` and `buildVm` resources in `infra/main.bicep`. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L2381-R2381) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L2424-R2424)


Dependant on #5 as the updates, push the size over 4 MB.